### PR TITLE
Allow pickling for loading predictions

### DIFF
--- a/code/experiments/scp_experiment.py
+++ b/code/experiments/scp_experiment.py
@@ -128,9 +128,9 @@ class SCP_Experiment():
         for model_description in os.listdir(self.outputfolder+self.experiment_name+'/models/'):
             if not model_description in ['ensemble', 'naive']:
                 mpath = self.outputfolder+self.experiment_name+'/models/'+model_description+'/'
-                ensemble_train.append(np.load(mpath+'y_train_pred.npy'))
-                ensemble_val.append(np.load(mpath+'y_val_pred.npy'))
-                ensemble_test.append(np.load(mpath+'y_test_pred.npy'))
+                ensemble_train.append(np.load(mpath+'y_train_pred.npy', allow_pickle=True))
+                ensemble_val.append(np.load(mpath+'y_val_pred.npy', allow_pickle=True))
+                ensemble_test.append(np.load(mpath+'y_test_pred.npy', allow_pickle=True))
         # dump mean predictions
         np.array(ensemble_train).mean(axis=0).dump(ensemblepath + 'y_train_pred.npy')
         np.array(ensemble_test).mean(axis=0).dump(ensemblepath + 'y_test_pred.npy')


### PR DESCRIPTION
I tried running `python reproduce_results.py`, subsetting the performed experiments with
```
    models = [
        conf_fastai_xresnet1d101  # ,
        # conf_fastai_resnet1d_wang,
        # conf_fastai_lstm,
        # conf_fastai_lstm_bidir,
        # conf_fastai_fcn_wang,
        # conf_fastai_inception1d,
        # conf_wavelet_standard_nn,
    ]

    ##########################################
    # STANDARD SCP EXPERIMENTS ON PTBXL
    ##########################################

    experiments = [
        # ('exp0', 'all'),
        ("exp1", "diagnostic")  # ,
        # ('exp1.1', 'subdiagnostic'),
        # ('exp1.1.1', 'superdiagnostic'),
        # ('exp2', 'form'),
        # ('exp3', 'rhythm')
    ]
```

I observed the following issue:

```
Training from scratch...
model: fastai_xresnet1d101
epoch     train_loss  valid_loss  time    
0         3.974695    #na#        00:37     
LR Finder is complete, type {learner_name}.recorder.plot() to see the graph.
epoch     train_loss  valid_loss  time    
0         0.749000    0.617362    00:26     
1         0.473438    0.320645    00:26     
2         0.176713    0.144030    00:26     
3         0.108897    0.087803    00:26     
4         0.090648    0.088311    00:26     
5         0.087162    1.318479    00:26     
6         0.081824    0.075645    00:26     
7         0.082379    0.417358    00:26     
8         0.076183    0.074853    00:26     
9         0.073203    0.072046    00:26     
10        0.069833    0.071563    00:26     
11        0.068211    0.072181    00:27     
12        0.066698    0.068252    00:27     
13        0.064080    0.065109    00:27     
14        0.062807    0.064614    00:27     
15        0.062573    0.064388    00:27     
16        0.060904    0.063040    00:27     
17        0.060706    0.061243    00:27     
18        0.058977    0.061040    00:27     
19        0.058891    0.062251    00:27     
20        0.058370    0.060759    00:27     
21        0.056846    0.059595    00:27     
22        0.056774    0.059208    00:27     
23        0.055560    0.062082    00:27     
24        0.055347    0.059120    00:27     
25        0.054211    0.059825    00:27     
26        0.054380    0.060731    00:27     
27        0.054117    0.061301    00:27     
28        0.053299    0.060714    00:27     
29        0.052234    0.059627    00:27     
30        0.051338    0.058611    00:27     
31        0.050798    0.056932    00:27     
32        0.050442    0.056777    00:27     
33        0.049988    0.060446    00:27     
34        0.048720    0.057679    00:26     
35        0.048680    0.057815    00:26     
36        0.047615    0.056821    00:26     
37        0.046539    0.057558    00:26     
38        0.046356    0.057474    00:26     
39        0.046132    0.057675    00:26     
40        0.045098    0.057444    00:26     
41        0.044321    0.057479    00:26     
42        0.043867    0.057333    00:26     
43        0.043355    0.058301    00:27     
44        0.043441    0.057717    00:26     
45        0.042899    0.058201    00:26     
46        0.042278    0.057848    00:26     
47        0.042592    0.057989    00:26     
48        0.043062    0.058147    00:26     
49        0.042745    0.058259    00:26     
model: fastai_xresnet1d101
aggregating predictions...
model: fastai_xresnet1d101
aggregating predictions...
model: fastai_xresnet1d101
aggregating predictions...
Traceback (most recent call last):
  File "reproduce_results.py", line 59, in <module>
    main()
  File "reproduce_results.py", line 40, in main
    e.perform()
  File "/home/rsaite/medalcare/ecg_ptbxl_benchmarking/code/experiments/scp_experiment.py", line 131, in perform
    ensemble_train.append(np.load(mpath+'y_train_pred.npy'))
  File "/home/rsaite/anaconda3/envs/ecg_ptbxl/lib/python3.7/site-packages/numpy/lib/npyio.py", line 457, in load
    raise ValueError("Cannot load file containing pickled data "
ValueError: Cannot load file containing pickled data when allow_pickle=False
```

After setting `allow_pickle=True`, the script runs to completion.