### PR TITLE
Fix README typo and various spellings

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install the dependencies (wfdb, pytorch, torchvision, cudatoolkit, fastai, fastp
     conda activate ecg_env
 
 ### Get data
-Download and prepare the datasets (PTB-XL and ICBEB) via the follwing bash-script:
+Download and prepare the datasets (PTB-XL and ICBEB) via the following bash-script:
 
     ./get_datasets.sh
 
@@ -64,8 +64,8 @@ e.evaluate()
 ```
 
 ### Notes on e.evaluate()
-Altough we recommend to use our framework, custom evaluation of custom models is still possible via calling `code.utils.utils.evaluate_experiment(y_true, y_pred, thresholds)` 
-manually with classwise thresholds. 
+Although we recommend using our framework, custom evaluation of custom models is still possible via calling `code.utils.utils.evaluate_experiment(y_true, y_pred, thresholds)`
+manually with classwise thresholds.
 
 For `e.evaluate()`: If the name of the experiment is `exp_ICBEB` classifier thresholds are needed. 
 In any other case `evaluate_experiment(y_true, y_pred)` will return a dictionary with `macro_auc` and `Fmax` (both metrics are **without any explicitly needed thresholds**). 

--- a/code/models/basic_conv1d.py
+++ b/code/models/basic_conv1d.py
@@ -71,7 +71,7 @@ class SqueezeExcite1d(nn.Module):
         return s*x #bs,ch,seq * bs, ch,1 = bs,ch,seq
 
 def weight_init(m):
-    '''call weight initialization for model n via n.appy(weight_init)'''
+    '''call weight initialization for model n via n.apply(weight_init)'''
     if isinstance(m, nn.Conv1d) or isinstance(m, nn.Linear):
         nn.init.kaiming_normal_(m.weight)
         if m.bias is not None:

--- a/code/models/timeseries_utils.py
+++ b/code/models/timeseries_utils.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from scipy.stats import iqr
 import os
 
-#Note: due to issues with the numpy rng for multiprocessing (https://github.com/pytorch/pytorch/issues/5059) that could be fixed by a custom worker_init_fn we use random throught for convenience
+# Note: due to issues with the numpy RNG for multiprocessing (https://github.com/pytorch/pytorch/issues/5059) that could be fixed by a custom worker_init_fn, we use randomness throughout for convenience
 import random
 
 from skimage import transform

--- a/code/reproduce_results.py
+++ b/code/reproduce_results.py
@@ -40,7 +40,7 @@ def main():
         e.perform()
         e.evaluate()
 
-    # generate greate summary table
+    # generate great summary table
     utils.generate_ptbxl_summary_table()
 
     ##########################################
@@ -52,7 +52,7 @@ def main():
     e.perform()
     e.evaluate()
 
-    # generate greate summary table
+    # generate great summary table
     utils.ICBEBE_table()
 
 if __name__ == "__main__":

--- a/code/utils/stratisfy.py
+++ b/code/utils/stratisfy.py
@@ -13,7 +13,7 @@ def stratisfy_df(df, new_col_name, n_folds=10, nr_clean_folds=0):
         quals.append(q)
     df['quality'] = quals
 
-    # create stratisfied folds according to patients
+    # create stratified folds according to patients
     pat_ids = np.array(sorted(list(set(df.patient_id.values))))
     plabels = []
     pquals = []
@@ -154,7 +154,7 @@ def stratify(data, classes, ratios, qualities, ecgs_per_patient, nr_clean_folds=
             for x in per_label_data.keys():
                 per_label_data[x] = [y for y in per_label_data[x] if y!=current_id]
               
-    # Create the stratified dataset as a list of subsets, each containing the orginal labels
+    # Create the stratified dataset as a list of subsets, each containing the original labels
     stratified_data_ids = [sorted(strat) for strat in stratified_data_ids]
     stratified_data = [
         [data[i] for i in strat] for strat in stratified_data_ids


### PR DESCRIPTION
## Summary
- fix README typo on data script line
- clarify evaluation notes wording
- correct spelling in reproduce_results.py and utils
- clean up comments in model utilities

## Testing
- `codespell -q 3`


------
https://chatgpt.com/codex/tasks/task_e_68405144b960832eb50a26930223debf